### PR TITLE
Fixing spigot plugins path for windows

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -47,7 +47,8 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <configuration>
                     <tasks>
-                        <copy file="target/${artifactId}-${version}.jar" todir="${spigot}/plugins"/>
+                        <property name="spigot.basedir" location="${spigot}"/>
+                        <copy file="target/${artifactId}-${version}.jar" todir="${spigot.basedir}/plugins"/>
                     </tasks>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Arun,

As mentionned in my mail, maven try copy to windows to the following directory:
E:\minecraft\spigot/plugins
where the correct value should have been:
E:\minecraft\spigot\plugins

Java is not able to mix both windows and unix path format.
The way to fix it is to tell java that ${spigot} is a path with an OS specific format.
And then use that value to get the sub directory with the java path format.

Cheers,
Cyril
